### PR TITLE
remove glossary section

### DIFF
--- a/reference.md
+++ b/reference.md
@@ -2,8 +2,4 @@
 layout: reference
 ---
 
-## Glossary
-
-FIXME
-
 {% include links.md %}


### PR DESCRIPTION
To remove the heading if you do not wish to include a glossary for this overview site.